### PR TITLE
Screenshot resolution to FHD for local and browserstack

### DIFF
--- a/browserstack/chrome.json
+++ b/browserstack/chrome.json
@@ -1,11 +1,11 @@
 {
-  "project":"KlassiTech Automated Test",
+  "project":"SchulCloud Automated Tests",
 
   "os": "Windows",
   "os_version": "10",
   "browserName": "Chrome",
   "browser_version": "66.0",
-  "resolution": "1280x800",
+  "resolution": "1920x1080",
   "chromeOptions": {
     "args": ["disable-infobars"]
   },

--- a/browserstack/chrome.json
+++ b/browserstack/chrome.json
@@ -7,7 +7,8 @@
   "browser_version": "66.0",
   "resolution": "1920x1080",
   "chromeOptions": {
-    "args": ["disable-infobars"]
+    "args": ["disable-infobars",
+             "window-size=1920,1080"]
   },
 
   "javascriptEnabled":true,

--- a/browserstack/macChrome.json
+++ b/browserstack/macChrome.json
@@ -7,7 +7,8 @@
   "browser_version": "66.0",
   "resolution": "1920x1080",
   "chromeOptions": {
-    "args": ["disable-infobars"]
+    "args": ["disable-infobars",
+             "window-size=1920,1080"]
   },
 
   "javascriptEnabled":true,

--- a/browserstack/macChrome.json
+++ b/browserstack/macChrome.json
@@ -1,11 +1,11 @@
 {
-  "project":"KlassiTech Automated Test",
+  "project":"SchulCloud Automated Tests",
 
   "os": "OS X",
   "os_version": "Sierra",
   "browserName": "Chrome",
   "browser_version": "66.0",
-  "resolution": "1280x960",
+  "resolution": "1920x1080",
   "chromeOptions": {
     "args": ["disable-infobars"]
   },

--- a/runtime/chromeDriver.js
+++ b/runtime/chromeDriver.js
@@ -62,8 +62,8 @@ module.exports = function chromeDriver(options){
     /**
      * sets the browser window size to maximum or a particular size
      */
-    driver.windowHandleMaximize();
-    // driver.windowHandleSize({width: 1024, height: 800});
+    // driver.windowHandleMaximize();
+    driver.windowHandleSize({width: 1920, height: 1080});
   });
   
   return driver;

--- a/runtime/imageCompare.js
+++ b/runtime/imageCompare.js
@@ -42,6 +42,7 @@ module.exports ={
    * @method saveScreenshot
    * @param {string} filename The complete path to the file name where the screenshot should be saved.
    * @param filename
+   * @param elementsToHide Css selectors for elements that should be hidden (because they are dynamic) in order to make the screenshot comparable.
    * @returns {Promise<void>}
    */
   saveScreenshot: async function(filename, elementsToHide) {


### PR DESCRIPTION
Changes made to chromedriver.js (for local testing) and to chrome.json (for browserstack testing) so that tests are always run in Full HD. 

Also added a param-explanation for the elementsToHide param. 