### PR TITLE
moved integration-test script from gist into repo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ jobs:
       script:
         - echo $TRAVIS_BRANCH
         - echo $TRAVIS_TAG
-        - curl "https://gist.githubusercontent.com/schul-cloud-bot/0cba8294a2faab5743eefea69f956541/raw/fetch.travis.sh" | bash
+        - curl "https://raw.githubusercontent.com/schul-cloud/integration-tests/master/scripts/ci/fetch.travis.sh" | bash
       name: "test:integration"
       env:
         - IT_CLIENT_HOST=nuxtclient

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,9 +17,7 @@ jobs:
       script:
         - echo $TRAVIS_BRANCH
         - echo $TRAVIS_TAG
-        - curl https://gist.githubusercontent.com/schul-cloud-bot/a849c38804174f99ca7818782bf03c00/raw/index.sh > integration-test.sh
-        - chmod 700 integration-test.sh
-        - bash integration-test.sh
+        - curl "https://gist.githubusercontent.com/schul-cloud-bot/0cba8294a2faab5743eefea69f956541/raw/fetch.travis.sh" | bash
       name: "test:integration"
       env:
         - IT_CLIENT_HOST=nuxtclient

--- a/scripts/ci/integration-test.travis.sh
+++ b/scripts/ci/integration-test.travis.sh
@@ -1,0 +1,74 @@
+#! /bin/bash
+
+export BRANCH_NAME=${TRAVIS_PULL_REQUEST_BRANCH:=$TRAVIS_BRANCH}
+
+_switchBranch(){
+  cd $1
+  echo "switching branch..."
+  git checkout $2 > /dev/null 2>&1 || true
+  echo "(new) active branch for $1:"
+  git branch | grep \* | cut -d ' ' -f2
+  cd ..
+}
+
+switchBranch(){
+  if [[ $BRANCH_NAME = release* || $BRANCH_NAME = hotfix* ]]
+  then
+    _switchBranch "$1" "master"
+  fi
+  _switchBranch "$1" "$BRANCH_NAME"
+}
+
+fetch(){
+  # clone all required repositories and try to switch to branch with same name as current one
+  git clone https://github.com/schul-cloud/nuxt-client.git nuxt-client
+  switchBranch "nuxt-client"
+
+  git clone https://github.com/schul-cloud/schulcloud-client.git schulcloud-client
+  switchBranch "schulcloud-client"
+
+  git clone https://github.com/schul-cloud/schulcloud-server.git schulcloud-server
+  switchBranch "schulcloud-server"
+
+  git clone https://github.com/schul-cloud/docker-compose.git docker-compose
+  switchBranch "docker-compose"
+
+  git clone https://github.com/schul-cloud/integration-tests.git integration-tests
+  switchBranch "integration-tests"
+
+  git clone https://github.com/schul-cloud/node-notification-service.git node-notification-service
+  switchBranch "node-notification-service"
+}
+
+install(){
+  npm install -g wait-on
+
+  cd docker-compose
+  docker-compose -f docker-compose.integration-test.yml build --parallel
+  docker-compose -f docker-compose.integration-test.yml up -d
+  cd ..
+
+  cd integration-tests && npm ci && cd ..
+}
+
+before(){
+  cd schulcloud-server && npm run setup && npm run seed && cd ..
+
+  # wait for the nuxt client to be available
+  echo "waiting max 150s for nuxt to be available"
+  wait-on http://localhost:4000 -t 150000
+  echo "nuxt is now online"
+}
+
+main(){
+  cd integration-tests
+  npm run test
+  cd ..
+}
+
+set -e
+fetch
+install
+before
+main
+set +e


### PR DESCRIPTION
This moves the script to execute integration tests from the gist into this repo. This enables a better version control and branch specific updates where we can test new configurations without breaking all other runs. The gist part is now super generic and only fetches the branched version of the script to execute.

PRs:
https://github.com/schul-cloud/schulcloud-client/pull/1605
https://github.com/schul-cloud/schulcloud-server/pull/961
https://github.com/schul-cloud/nuxt-client/pull/600