### PR TITLE
Revert "added extra wait for teams-name"

### DIFF
--- a/page-objects/createTeam.js
+++ b/page-objects/createTeam.js
@@ -39,7 +39,6 @@ module.exports = {
     },
     setTeamName: async function(name) {
         let nameField = await driver.$(teamData.teamName);
-        await nameField.waitForDisplayed(15000);
         await nameField.setValue(name);
     },
     confirmTeamCreate: async function() {


### PR DESCRIPTION
Reverts schul-cloud/integration-tests#55

(Thought it was necessary for one of my PR's to go green. Later it turned out, that a single wrong character in the client PR caused my server PR to fail. I didn't know that a client PR could block a server PR...)