### PR TITLE
Update pullapprove to the group of gernal

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -4,7 +4,9 @@ pullapprove_conditions:
 - condition: "'WIP' not in labels"
   unmet_status: pending
   explanation: "Work in progress"
-
+- condition: "'- [ ]' not in body"
+  unmet_status: failure
+  explanation: "Please finish all the required checklist tasks"
 
 notifications:
 - when: pull_request.opened
@@ -16,9 +18,9 @@ notifications:
   comment: "The review is completed. Thanks @{{ author }}, we'll take it from here."
 
 groups:
-  test-core:
+  general:
     reviewers:
       teams:
-      - test-core
+      - general
     reviews:
       required: 1  # number of approvals required from this group


### PR DESCRIPTION
# Description
Next step on the new group plann for github.
Change the group to gerneral who is requeierd by pullaporve to approve pull request.

## Links to Tickets or other pull requests
hpi-schul-cloud/schulcloud-server#3145
hpi-schul-cloud/schulcloud-client#2700
hpi-schul-cloud/nuxt-client#1950

## Changes
Change the group to gerneral who is requeierd by pullaporve to approve pull request.

## Approval for review
- [x] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.

### Link to Definiton of Done
More and detailed information on the *definition of done* can be found [on Confluence](https://docs.hpi-schul-cloud.org/pages/viewpage.action?pageId=92831762)
